### PR TITLE
Add Metr format support with task-start, snapshot, and status commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The command prompts for:
 ```
 === TASK START ===
 Task ID: 1
-Time: 09:30
+Time: 2024-01-15 09:30
 Description: Implement user authentication
 
 1. WILL USE AI? Yes
@@ -182,7 +182,7 @@ Task name -- 30 min, 4 hours without
 ============================================================
 TASK END
 Task: Metr Task Tracking using cowork
-Clock: 11:46 AM - 03:01 PM
+Clock: 2024-01-15 11:46 AM - 03:01 PM
 Focused time: 2.8hr
 AI %: 33.2% (Claude 33.2%)
 With-AI estimate: 30 min
@@ -197,7 +197,7 @@ Notes: App breakdown - Claude: 33.2%, Conductor: 25.2%, Slack: 22.4%
 ```
 === TASK END ===
 Task ID: 1
-Time: 15:01
+Time: 2024-01-15 15:01
 
 1. USED AI? Yes
 2. TOTAL ELAPSED: 168 min
@@ -243,7 +243,7 @@ The command prompts for:
 
 ```
 === SNAPSHOT ===
-Time: 10:45
+Time: 2024-01-15 10:45
 
 1. AI INVOLVED? Yes-actively using
 2. FOCUS: Fully on one thing

--- a/README.md
+++ b/README.md
@@ -1,14 +1,34 @@
 # toggl_db
 
-A read-only CLI tool for exploring your local Toggl Track SQLite database and generating Metr TASK END reports.
+A read-only CLI tool for exploring your local Toggl Track SQLite database and generating Metr productivity research reports.
 
 ## Features
 
-- **Metr TASK END reports** - Generate productivity reports with AI usage breakdown
+- **Metr productivity reports** - Generate TASK START, TASK END, and SNAPSHOT reports
 - **Strictly read-only** - Multiple safety layers prevent any database modifications
 - **Auto-discovery** - Automatically finds your Toggl database on macOS, Linux, and Windows
-- **Flexible output** - Table, JSON, and CSV formats
+- **Flexible output** - Default (human-friendly) or strict Metr format
+- **Task tracking** - Local bookkeeping for Metr Task IDs and metadata
 - **Persistent config** - Save your database path and preferences
+
+## How Task Tracking Works
+
+**Important:** The `task-start` command creates a local record for Metr reporting purposes - it does **not** start a timer in the Toggl app.
+
+The workflow is:
+
+1. **Start your Toggl timer** manually in the Toggl app
+2. **Run `task-start`** to record Metr metadata (Task ID, AI intent, time estimates)
+3. **Work on your task**, optionally running `snapshot` periodically
+4. **Run `task-end`** to generate the Metr report (reads your Toggl time entries)
+
+The "tracking" is bookkeeping for Metr's required fields that Toggl doesn't capture:
+- Auto-incrementing Task IDs
+- Pre-task AI usage intent and time estimates
+- Confidence levels and task types
+- Periodic snapshots of work status
+
+Task data is stored locally in `~/.config/toggl_db/tasks.json`.
 
 ## Installation
 
@@ -24,8 +44,19 @@ bundle install
 # Find your Toggl database
 bin/toggl_db find
 
-# Generate a Metr TASK END report
-bin/toggl_db task-end
+# Typical Metr workflow:
+# 1. Start your Toggl timer in the Toggl app
+# 2. Record Metr task metadata
+bin/toggl_db task-start
+
+# 3. Periodically record snapshots (optional)
+bin/toggl_db snapshot
+
+# 4. When done, generate the TASK END report
+bin/toggl_db task-end --format metr
+
+# Check task status anytime
+bin/toggl_db status
 
 # Explore database tables
 bin/toggl_db db tables
@@ -33,11 +64,19 @@ bin/toggl_db db tables
 
 ## Commands
 
-### High-Level Commands
+### Metr Productivity Commands
 
 | Command | Description |
 |---------|-------------|
-| `task-end` | Generate a Metr TASK END report from today's entries |
+| `task-start` | Start a new Metr task (records metadata, does NOT start Toggl timer) |
+| `task-end` | Generate a Metr TASK END report from Toggl time entries |
+| `snapshot` | Record a point-in-time work status snapshot |
+| `status` | Show current task and recent task history |
+
+### Utility Commands
+
+| Command | Description |
+|---------|-------------|
 | `find` | Find and display the Toggl database location |
 | `config` | Manage configuration settings |
 | `version` | Show version information |
@@ -53,9 +92,51 @@ bin/toggl_db db tables
 | `db search TERM` | Search for tables/columns by name |
 | `db locations` | Show database search priority and paths |
 
+## task-start Command
+
+Begin a new Metr task by recording metadata locally. This does **not** start a Toggl timer - you should start your Toggl timer separately.
+
+```bash
+# Interactive mode - prompts for all fields
+bin/toggl_db task-start
+
+# Output in strict Metr format
+bin/toggl_db task-start --format metr
+
+# Write output to file
+bin/toggl_db task-start -o ~/tasks.txt
+```
+
+The command prompts for:
+- Task description
+- Whether you'll use AI (Yes/No)
+- Expected time with AI (minutes)
+- Without-AI estimate (minutes)
+- Confidence level (1-5)
+- Why you're using AI (if applicable)
+- Whether you would do this without AI
+- Task type (Code, Debug, Research, Write, Meet, Plan, Break, Other)
+
+### Output Example (Metr format)
+
+```
+=== TASK START ===
+Task ID: 1
+Time: 09:30
+Description: Implement user authentication
+
+1. WILL USE AI? Yes
+2. EXPECTED TIME: 30 min
+3. WITHOUT AI WOULD TAKE: 120 min
+4. CONFIDENCE (1-5): 3
+5. WHY AI? Complex logic, good for pair programming
+6. WOULD DO WITHOUT AI? Yes
+7. TYPE: Code
+```
+
 ## task-end Command
 
-Generate Metr TASK END reports for productivity research:
+Generate Metr TASK END reports from your Toggl time entries:
 
 ```bash
 # Show today's entries and pick which to report
@@ -64,8 +145,14 @@ bin/toggl_db task-end
 # Specify time range
 bin/toggl_db task-end --from "8:30am"
 
-# Interactive mode for entering estimates
+# Interactive mode - prompts for all Metr fields
 bin/toggl_db task-end --interactive
+
+# Strict Metr format output
+bin/toggl_db task-end --format metr
+
+# Write output to file
+bin/toggl_db task-end -o ~/report.txt
 ```
 
 ### Selection Interface
@@ -89,7 +176,7 @@ Task name -- 30 min, 4 hours without
 - Second value (4 hours) = Without-AI estimate
 - Use `-- continue` for continuation entries
 
-### Output Example
+### Output Example (default format)
 
 ```
 ============================================================
@@ -103,6 +190,93 @@ Without-AI estimate: 4 hours
 Quality: [1-5]
 Notes: App breakdown - Claude: 33.2%, Conductor: 25.2%, Slack: 22.4%
 ============================================================
+```
+
+### Output Example (Metr format with `--format metr`)
+
+```
+=== TASK END ===
+Task ID: 1
+Time: 15:01
+
+1. USED AI? Yes
+2. TOTAL ELAPSED: 168 min
+3. TIME BREAKDOWN:
+   Active work: 150 min
+   Waiting/reviewing AI: 18 min
+4. OUTCOME: Completed
+5. IF USED AI:
+   % from AI: 33.2
+   # of AI turns: 25
+6. WITHOUT AI WOULD TAKE: 240 min
+7. IF USED AI - QUALITY vs yourself: Slightly better
+8. NOTES: Claude: 33.2%, Conductor: 25.2%, Slack: 22.4%
+```
+
+## snapshot Command
+
+Record a point-in-time snapshot of your current work status:
+
+```bash
+# Interactive snapshot
+bin/toggl_db snapshot
+
+# Strict Metr format
+bin/toggl_db snapshot --format metr
+
+# Append to file (useful for multiple snapshots)
+bin/toggl_db snapshot -o ~/snapshots.txt --append
+
+# Link to a specific task
+bin/toggl_db snapshot --task-id 3
+```
+
+The command prompts for:
+- AI involvement (No, Yes-waiting, Yes-actively using, Yes-using output)
+- Focus level (Fully on one thing, Switching, Distracted)
+- Same task as last snapshot (Yes, No, Don't know)
+- If AI vanished impact (Unaffected, Somewhat longer, Much longer, Blocked)
+- What you're doing (one line)
+- Task type
+
+### Output Example (Metr format)
+
+```
+=== SNAPSHOT ===
+Time: 10:45
+
+1. AI INVOLVED? Yes-actively using
+2. FOCUS: Fully on one thing
+3. SAME TASK AS LAST SNAPSHOT? Yes
+4. IF AI VANISHED: Somewhat longer
+5. WHAT: Writing authentication middleware
+   Type: Code
+```
+
+## status Command
+
+Show current task and recent history:
+
+```bash
+bin/toggl_db status
+bin/toggl_db status --limit 10
+```
+
+Output:
+```
+Current Task:
+  #3: Implement user authentication
+  Type: Code
+  Started: 2024-01-15T09:00:00Z
+  AI: Yes
+  Snapshots: 2
+
+Recent Tasks (last 5):
+  #3: Implement user authentication [active]
+  #2: Fix login bug [done]
+  #1: Setup project [done]
+
+Task store: /Users/you/.config/toggl_db/tasks.json
 ```
 
 ## Global Options

--- a/lib/toggl_db/cli.rb
+++ b/lib/toggl_db/cli.rb
@@ -4,7 +4,11 @@ require 'thor'
 require 'json'
 require_relative '../toggl_db'
 require_relative 'cli/db_commands'
+require_relative 'cli/metr_formatter'
 require_relative 'cli/task_end_command'
+require_relative 'cli/task_start_command'
+require_relative 'cli/snapshot_command'
+require_relative 'task_store'
 
 module TogglDb
   class CLI < Thor
@@ -111,7 +115,54 @@ module TogglDb
       end
     end
 
+    desc 'status', 'Show current task status and recent tasks'
+    long_desc <<~DESC
+      Shows the current in-progress task (if any) and recent task history.
+
+      Example:
+        $ toggl_db status
+    DESC
+    option :limit, aliases: '-l', type: :numeric, default: 5,
+                   desc: 'Number of recent tasks to show'
+    def status
+      say ''
+      display_current_task
+      say ''
+      display_recent_tasks
+      say ''
+      say "Task store: #{TaskStore.path}", :cyan
+    end
+
     private
+
+    def display_current_task
+      current = TaskStore.current_task
+      if current
+        say 'Current Task:', :green
+        say "  ##{current['id']}: #{current['description']}"
+        say "  Type: #{current['type']}"
+        say "  Started: #{current['started_at']}"
+        say "  AI: #{current['use_ai'] ? 'Yes' : 'No'}"
+        snapshots = current['snapshots']&.length || 0
+        say "  Snapshots: #{snapshots}"
+      else
+        say 'No task in progress.', :yellow
+        say "Use 'toggl_db task-start' to begin a new task."
+      end
+    end
+
+    def display_recent_tasks
+      recent = TaskStore.recent_tasks(options[:limit])
+      if recent.any?
+        say "Recent Tasks (last #{options[:limit]}):", :green
+        recent.each do |task|
+          status_indicator = task['ended_at'] ? 'done' : 'active'
+          say "  ##{task['id']}: #{task['description']} [#{status_indicator}]"
+        end
+      else
+        say 'No tasks recorded yet.', :yellow
+      end
+    end
 
     def config_list
       say "Config file: #{Config.path}", :green

--- a/lib/toggl_db/cli.rb
+++ b/lib/toggl_db/cli.rb
@@ -19,6 +19,9 @@ module TogglDb
       true
     end
 
+    # Remove the built-in tree command (shows confusing internal naming)
+    remove_command :tree
+
     # Register the db subcommand for advanced database exploration
     desc 'db SUBCOMMAND', 'Database exploration commands (advanced)'
     subcommand 'db', DbCommands

--- a/lib/toggl_db/cli/metr_formatter.rb
+++ b/lib/toggl_db/cli/metr_formatter.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+module TogglDb
+  # Metr-specific output formatting for productivity research templates.
+  # Provides both strict Metr format and human-friendly default format.
+  # rubocop:disable Metrics/ModuleLength
+  module MetrFormatter
+    # Constants for choice fields
+    TASK_TYPES = %w[Code Debug Research Write Meet Plan Break Other].freeze
+
+    OUTCOMES = [
+      'Completed',
+      'Reduced scope',
+      'Abandoned',
+      'Still in progress'
+    ].freeze
+
+    QUALITY_RATINGS = [
+      'Notably worse',
+      'Slightly worse',
+      'Same',
+      'Slightly better',
+      'Notably better'
+    ].freeze
+
+    AI_INVOLVED_OPTIONS = [
+      'No',
+      'Yes-waiting',
+      'Yes-actively using',
+      'Yes-using output'
+    ].freeze
+
+    FOCUS_OPTIONS = [
+      'Fully on one thing',
+      'Switching',
+      'Distracted'
+    ].freeze
+
+    AI_VANISHED_OPTIONS = [
+      'Unaffected',
+      'Somewhat longer',
+      'Much longer',
+      'Blocked'
+    ].freeze
+
+    YES_NO_DK_OPTIONS = ['Yes', 'No', "Don't know"].freeze
+
+    module_function
+
+    def format_task_start(task, format: :metr)
+      case format.to_sym
+      when :metr
+        format_task_start_metr(task)
+      else
+        format_task_start_default(task)
+      end
+    end
+
+    def format_task_end(data, format: :metr)
+      case format.to_sym
+      when :metr
+        format_task_end_metr(data)
+      else
+        format_task_end_default(data)
+      end
+    end
+
+    def format_snapshot(data, format: :metr)
+      case format.to_sym
+      when :metr
+        format_snapshot_metr(data)
+      else
+        format_snapshot_default(data)
+      end
+    end
+
+    # --- TASK START formatters ---
+
+    def format_task_start_metr(task)
+      lines = []
+      lines << '=== TASK START ==='
+      lines << "Task ID: #{task['id']}"
+      lines << "Time: #{format_time(task['started_at'])}"
+      lines << "Description: #{task['description']}"
+      lines << ''
+      lines << "1. WILL USE AI? #{task['use_ai'] ? 'Yes' : 'No'}"
+      lines << "2. EXPECTED TIME: #{task['expected_time_minutes']} min"
+      lines << "3. WITHOUT AI WOULD TAKE: #{task['without_ai_time_minutes']} min"
+      lines << "4. CONFIDENCE (1-5): #{task['confidence']}"
+      lines << "5. WHY AI? #{task['why_ai'] || '[not specified]'}"
+      lines << "6. WOULD DO WITHOUT AI? #{task['would_do_without_ai'] ? 'Yes' : 'No'}"
+      lines << "7. TYPE: #{task['type']}"
+      lines.join("\n")
+    end
+
+    def format_task_start_default(task)
+      lines = []
+      lines << ('=' * 60)
+      lines << 'TASK START'
+      lines << "Task ID: #{task['id']}"
+      lines << "Description: #{task['description']}"
+      lines << "Started: #{format_time(task['started_at'])}"
+      lines << "Type: #{task['type']}"
+      lines << ''
+      lines << "Will use AI: #{task['use_ai'] ? 'Yes' : 'No'}"
+      lines << "Expected time: #{task['expected_time_minutes']} min"
+      lines << "Without AI estimate: #{task['without_ai_time_minutes']} min"
+      lines << "Confidence: #{task['confidence']}/5"
+      lines << "Why AI: #{task['why_ai']}" if task['why_ai']
+      lines << "Would do without AI: #{task['would_do_without_ai'] ? 'Yes' : 'No'}"
+      lines << ('=' * 60)
+      lines.join("\n")
+    end
+
+    # --- TASK END formatters ---
+
+    # rubocop:disable Metrics/AbcSize
+    def format_task_end_metr(data)
+      lines = []
+      lines << '=== TASK END ==='
+      lines << "Task ID: #{data[:task_id] || '[unknown]'}"
+      lines << "Time: #{format_time(data[:end_time])}"
+      lines << ''
+      lines << "1. USED AI? #{data[:used_ai] ? 'Yes' : 'No'}"
+      lines << "2. TOTAL ELAPSED: #{data[:total_elapsed_minutes]} min"
+      lines << '3. TIME BREAKDOWN:'
+      lines << "   Active work: #{data[:active_work_minutes] || '___'} min"
+      lines << "   Waiting/reviewing AI: #{data[:waiting_ai_minutes] || '___'} min"
+      lines << "4. OUTCOME: #{data[:outcome] || '[select]'}"
+      lines << '5. IF USED AI:'
+      lines << "   % from AI: #{data[:ai_percentage] || '___'}"
+      lines << "   # of AI turns: #{data[:ai_turns] || '___'}"
+      lines << "6. WITHOUT AI WOULD TAKE: #{data[:without_ai_minutes] || '___'} min"
+      lines << "7. IF USED AI - QUALITY vs yourself: #{data[:quality_vs_self] || '[select]'}"
+      lines << "8. NOTES: #{data[:notes] || ''}"
+      lines.join("\n")
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def format_task_end_default(data)
+      lines = []
+      lines << ('=' * 60)
+      lines << 'TASK END'
+      lines << "Task: #{data[:task_name]}"
+      lines << "Clock: #{data[:clock_range]}"
+      lines << "Focused time: #{format_duration_human(data[:total_elapsed_minutes])}"
+      lines << "AI %: #{data[:ai_percentage]}% (#{data[:ai_details]})"
+      lines << "With-AI estimate: #{data[:with_ai_estimate]}" if data[:with_ai_estimate]
+      lines << "Without-AI estimate: #{data[:without_ai_minutes] || '[YOU FILL IN]'}"
+      lines << "Quality: #{data[:quality_vs_self] || '[1-5]'}"
+      lines << "Notes: App breakdown - #{data[:app_breakdown_text]}" if data[:app_breakdown_text]
+      lines << ('=' * 60)
+      lines.join("\n")
+    end
+
+    # --- SNAPSHOT formatters ---
+
+    def format_snapshot_metr(data)
+      lines = []
+      lines << '=== SNAPSHOT ==='
+      lines << "Time: #{format_time(data[:time])}"
+      lines << ''
+      lines << "1. AI INVOLVED? #{data[:ai_involved] || '[select]'}"
+      lines << "2. FOCUS: #{data[:focus] || '[select]'}"
+      lines << "3. SAME TASK AS LAST SNAPSHOT? #{data[:same_task] || '[select]'}"
+      lines << "4. IF AI VANISHED: #{data[:ai_vanished_impact] || '[select]'}"
+      lines << "5. WHAT: #{data[:what] || '[description]'}"
+      lines << "   Type: #{data[:type] || '[select]'}"
+      lines.join("\n")
+    end
+
+    def format_snapshot_default(data)
+      lines = []
+      lines << ('=' * 60)
+      lines << 'SNAPSHOT'
+      lines << "Time: #{format_time(data[:time])}"
+      lines << ''
+      lines << "What: #{data[:what]}"
+      lines << "Type: #{data[:type]}"
+      lines << "AI involved: #{data[:ai_involved]}"
+      lines << "Focus: #{data[:focus]}"
+      lines << "Same task: #{data[:same_task]}"
+      lines << "If AI vanished: #{data[:ai_vanished_impact]}"
+      lines << ('=' * 60)
+      lines.join("\n")
+    end
+
+    # --- Helper methods ---
+
+    def format_time(time)
+      return Time.now.strftime('%H:%M') if time.nil?
+
+      case time
+      when String
+        Time.parse(time).strftime('%H:%M')
+      when Time
+        time.strftime('%H:%M')
+      else
+        time.to_s
+      end
+    end
+
+    def format_duration_human(minutes)
+      return "#{minutes}min" if minutes < 60
+
+      hours = minutes / 60.0
+      format('%.1fhr', hours)
+    end
+  end
+  # rubocop:enable Metrics/ModuleLength
+end

--- a/lib/toggl_db/cli/metr_formatter.rb
+++ b/lib/toggl_db/cli/metr_formatter.rb
@@ -188,13 +188,13 @@ module TogglDb
     # --- Helper methods ---
 
     def format_time(time)
-      return Time.now.strftime('%H:%M') if time.nil?
+      return Time.now.strftime('%Y-%m-%d %H:%M') if time.nil?
 
       case time
       when String
-        Time.parse(time).strftime('%H:%M')
+        Time.parse(time).strftime('%Y-%m-%d %H:%M')
       when Time
-        time.strftime('%H:%M')
+        time.strftime('%Y-%m-%d %H:%M')
       else
         time.to_s
       end

--- a/lib/toggl_db/cli/snapshot_command.rb
+++ b/lib/toggl_db/cli/snapshot_command.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative 'metr_formatter'
+require_relative '../task_store'
+
+module TogglDb
+  class CLI < Thor
+    desc 'snapshot', 'Record a Metr productivity snapshot'
+    long_desc <<~DESC
+      Records a point-in-time snapshot of current work status for Metr productivity research.
+
+      Prompts for:
+        - AI involvement (No, Yes-waiting, Yes-actively using, Yes-using output)
+        - Focus level (Fully on one thing, Switching, Distracted)
+        - Same task as last snapshot (Yes, No, Don't know)
+        - Impact if AI vanished (Unaffected, Somewhat longer, Much longer, Blocked)
+        - What you're doing (one line description)
+        - Task type (Code, Debug, Research, Write, Meet, Plan, Break, Other)
+
+      Examples:
+        $ toggl_db snapshot                       # Interactive snapshot
+        $ toggl_db snapshot --format metr        # Strict Metr format
+        $ toggl_db snapshot -o ~/snapshots.txt   # Append to file
+        $ toggl_db snapshot --task-id 3          # Link to task #3
+    DESC
+    option :format, aliases: '-f', type: :string, enum: %w[default metr], default: 'metr',
+                    desc: 'Output format'
+    option :output, aliases: '-o', type: :string, desc: 'Write output to file'
+    option :task_id, type: :numeric, desc: 'Link snapshot to a specific task ID'
+    option :append, aliases: '-a', type: :boolean, default: false,
+                    desc: 'Append to output file instead of overwriting'
+    def snapshot
+      snapshot_data = prompt_snapshot_data
+      task_id = options[:task_id] || TaskStore.current_task&.dig('id')
+
+      # Save to task store if we have a task
+      if task_id
+        TaskStore.add_snapshot(task_id, snapshot_data)
+        say "Snapshot added to task ##{task_id}", :cyan
+      end
+
+      output = MetrFormatter.format_snapshot(snapshot_data, format: options[:format].to_sym)
+      write_snapshot_output(output)
+    end
+
+    private
+
+    def prompt_snapshot_data
+      say ''
+      say 'Recording snapshot...', :green
+      say ''
+
+      {
+        time: Time.now,
+        ai_involved: ask_snapshot_choice('AI involved?', MetrFormatter::AI_INVOLVED_OPTIONS),
+        focus: ask_snapshot_choice('Focus level:', MetrFormatter::FOCUS_OPTIONS),
+        same_task: ask_yes_no_dk('Same task as last snapshot?'),
+        ai_vanished_impact: ask_snapshot_choice('If AI vanished:', MetrFormatter::AI_VANISHED_OPTIONS),
+        what: ask('What are you doing (one line):'),
+        type: ask_snapshot_choice('Type:', MetrFormatter::TASK_TYPES)
+      }
+    end
+
+    def ask_snapshot_choice(prompt, choices)
+      say prompt
+      choices.each_with_index { |c, i| say "  #{i + 1}. #{c}" }
+      response = ask("Select (1-#{choices.length}):")
+      idx = response.to_i - 1
+      idx >= 0 && idx < choices.length ? choices[idx] : choices.first
+    end
+
+    def ask_yes_no_dk(prompt)
+      say prompt
+      say '  1. Yes'
+      say '  2. No'
+      say "  3. Don't know"
+      response = ask('Select (1-3):')
+      case response.to_i
+      when 1 then 'Yes'
+      when 2 then 'No'
+      else "Don't know"
+      end
+    end
+
+    def write_snapshot_output(output)
+      if options[:output]
+        mode = options[:append] ? 'a' : 'w'
+        File.open(options[:output], mode) do |f|
+          f.puts output
+          f.puts '' if options[:append] # Add blank line between snapshots
+        end
+        action = options[:append] ? 'Appended to' : 'Written to'
+        say "#{action}: #{options[:output]}", :green
+      else
+        say ''
+        say output
+      end
+    end
+  end
+end

--- a/lib/toggl_db/cli/task_end_command.rb
+++ b/lib/toggl_db/cli/task_end_command.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'time'
+require_relative 'metr_formatter'
+require_relative '../task_store'
 
 module TogglDb
   class CLI < Thor
@@ -8,7 +10,7 @@ module TogglDb
     CORE_DATA_EPOCH = Time.utc(2001, 1, 1).to_i
 
     # Apps considered AI tools for percentage calculation
-    AI_APPS = %w[Claude ChatGPT Gemini Copilot Cursor].freeze
+    AI_APPS = %w[Claude ChatGPT Gemini Copilot Cursor Conductor].freeze
 
     # Metadata separator in task descriptions
     METADATA_SEPARATOR = ' -- '
@@ -26,15 +28,23 @@ module TogglDb
         1,3,5   (entries 1, 3, and 5)
         1-3,5   (entries 1 through 3, plus 5)
 
+      Use --format metr for strict Metr format output.
+
       Examples:
         $ toggl_db task-end                    # Show today's entries, pick one
         $ toggl_db task-end --from "8:30am"    # From 8:30am to now
-        $ toggl_db task-end --interactive      # Prompt for estimates
+        $ toggl_db task-end --interactive      # Prompt for all fields
+        $ toggl_db task-end --format metr      # Output in strict Metr format
+        $ toggl_db task-end -o ~/report.txt    # Write to file
     DESC
     option :from, type: :string, desc: 'Start time (e.g., "8:30am", "2024-01-15 09:00")'
     option :to, type: :string, desc: 'End time (e.g., "now", "5:30pm")'
     option :interactive, aliases: '-i', type: :boolean, default: false,
-                         desc: 'Prompt for Without-AI estimate and Quality rating'
+                         desc: 'Prompt for all Metr fields interactively'
+    option :format, aliases: '-f', type: :string, enum: %w[default metr], default: 'default',
+                    desc: 'Output format (default or metr)'
+    option :output, aliases: '-o', type: :string, desc: 'Write output to file'
+    option :task_id, type: :numeric, desc: 'Link to a tracked task ID'
     option :database, aliases: '-d', type: :string,
                       desc: 'Path to Toggl database (default: auto-discover)'
     def task_end
@@ -55,7 +65,14 @@ module TogglDb
       app_breakdown = calculate_app_breakdown(activities)
       ai_percentage = calculate_ai_percentage(app_breakdown)
 
-      print_task_end_report(combined, app_breakdown, ai_percentage)
+      # Determine task ID from option, current task, or prompt
+      task_id = determine_task_id
+
+      # Build report data
+      report_data = build_report_data(combined, app_breakdown, ai_percentage, task_id)
+
+      # Output in requested format
+      output_task_end_report(report_data)
     rescue DatabaseNotFoundError => e
       error_and_exit(e.message)
     ensure
@@ -251,37 +268,141 @@ module TogglDb
       }
     end
 
-    def print_task_end_report(entry, app_breakdown, ai_percentage)
-      estimates = extract_or_prompt_estimates(entry[:metadata])
-      say ''
-      say '=' * 60, :green
-      say 'TASK END', :green
-      say "Task: #{entry[:task_name]}"
-      say "Clock: #{format_time_range(entry)}"
-      say "Focused time: #{format_duration(entry[:duration_seconds])}"
-      say "AI %: #{ai_percentage}% (#{format_ai_details(app_breakdown)})"
-      say "With-AI estimate: #{estimates[:with_ai]}" if estimates[:with_ai]
-      say "Without-AI estimate: #{estimates[:without_ai]}"
-      say "Quality: #{estimates[:quality]}"
-      say "Notes: App breakdown - #{format_app_breakdown(app_breakdown)}" if app_breakdown.any?
-      say '=' * 60, :green
+    def determine_task_id
+      return options[:task_id] if options[:task_id]
+
+      current = TaskStore.current_task
+      return current['id'] if current
+
+      nil
     end
 
-    def extract_or_prompt_estimates(metadata)
-      # Try to parse metadata first: "30 min, 4 hours without"
-      if metadata
-        parsed = parse_metadata_estimates(metadata)
-        return parsed if parsed
+    def build_report_data(entry, app_breakdown, ai_percentage, task_id)
+      total_minutes = (entry[:duration_seconds] / 60.0).round
+      used_ai = ai_percentage.positive?
+
+      # Get user-provided fields if interactive or metr format
+      user_fields = prompt_task_end_fields(entry, total_minutes, ai_percentage)
+
+      {
+        task_id: task_id,
+        task_name: entry[:task_name],
+        end_time: entry[:end_time],
+        clock_range: format_time_range(entry),
+        used_ai: used_ai,
+        total_elapsed_minutes: total_minutes,
+        active_work_minutes: user_fields[:active_work_minutes],
+        waiting_ai_minutes: user_fields[:waiting_ai_minutes],
+        outcome: user_fields[:outcome],
+        ai_percentage: ai_percentage,
+        ai_turns: user_fields[:ai_turns],
+        without_ai_minutes: user_fields[:without_ai_minutes],
+        quality_vs_self: user_fields[:quality_vs_self],
+        with_ai_estimate: user_fields[:with_ai_estimate],
+        notes: format_app_breakdown(app_breakdown),
+        ai_details: format_ai_details(app_breakdown),
+        app_breakdown_text: format_app_breakdown(app_breakdown)
+      }
+    end
+
+    def prompt_task_end_fields(entry, total_minutes, ai_percentage)
+      # Try to parse metadata first
+      parsed = parse_metadata_estimates(entry[:metadata]) if entry[:metadata]
+      used_ai = ai_percentage.positive?
+
+      # If not interactive and not metr format, return minimal data
+      unless options[:interactive] || options[:format] == 'metr'
+        return {
+          with_ai_estimate: parsed&.dig(:with_ai),
+          without_ai_minutes: parsed&.dig(:without_ai) || '[YOU FILL IN]',
+          quality_vs_self: parsed&.dig(:quality) || '[1-5]',
+          active_work_minutes: nil,
+          waiting_ai_minutes: nil,
+          outcome: nil,
+          ai_turns: nil
+        }
       end
 
-      return { with_ai: nil, without_ai: '[YOU FILL IN]', quality: '[1-5]' } unless options[:interactive]
-
       say ''
+      say 'Collecting Metr task end data...', :green
+      say ''
+
+      # TIME BREAKDOWN
+      active_work = ask_numeric_field('Active work time (minutes):', default: total_minutes)
+      waiting_ai = used_ai ? ask_numeric_field('Waiting/reviewing AI time (minutes):', default: 0) : 0
+
+      # OUTCOME
+      outcome = ask_choice_field('Outcome:', MetrFormatter::OUTCOMES)
+
+      # AI fields
+      ai_turns = used_ai ? ask_numeric_field('Number of AI turns:') : nil
+
+      # Without AI estimate
+      without_ai_default = parsed&.dig(:without_ai)
+      without_ai = ask_numeric_field('Without AI would take (minutes):', default: without_ai_default&.to_i)
+
+      # Quality
+      quality = used_ai ? ask_choice_field('Quality vs yourself:', MetrFormatter::QUALITY_RATINGS) : nil
+
       {
-        with_ai: nil,
-        without_ai: ask('Without-AI estimate (e.g., "4 hours"):'),
-        quality: ask('Quality rating (1-5):')
+        with_ai_estimate: parsed&.dig(:with_ai),
+        without_ai_minutes: without_ai,
+        quality_vs_self: quality,
+        active_work_minutes: active_work,
+        waiting_ai_minutes: waiting_ai,
+        outcome: outcome,
+        ai_turns: ai_turns
       }
+    end
+
+    def ask_numeric_field(prompt, default: nil)
+      default_hint = default ? " [#{default}]" : ''
+      response = ask("#{prompt}#{default_hint}")
+      return default if response.strip.empty? && default
+
+      response.to_i
+    end
+
+    def ask_choice_field(prompt, choices, default: nil)
+      say prompt
+      choices.each_with_index { |c, i| say "  #{i + 1}. #{c}" }
+      default_idx = default ? choices.index(default) + 1 : nil
+      default_hint = default_idx ? " [#{default_idx}]" : ''
+      response = ask("Select (1-#{choices.length})#{default_hint}:")
+
+      return default if response.strip.empty? && default
+
+      idx = response.to_i - 1
+      idx >= 0 && idx < choices.length ? choices[idx] : (default || choices.first)
+    end
+
+    def output_task_end_report(data)
+      output = MetrFormatter.format_task_end(data, format: options[:format].to_sym)
+
+      if options[:output]
+        File.write(options[:output], "#{output}\n")
+        say "Output written to: #{options[:output]}", :green
+      else
+        say ''
+        say output
+      end
+
+      # Update task store if we have a task ID
+      update_task_store(data) if data[:task_id]
+    end
+
+    def update_task_store(data)
+      TaskStore.end_task(data[:task_id], {
+                           outcome: data[:outcome],
+                           actual_elapsed_minutes: data[:total_elapsed_minutes],
+                           active_work_minutes: data[:active_work_minutes],
+                           waiting_ai_minutes: data[:waiting_ai_minutes],
+                           ai_percentage: data[:ai_percentage],
+                           ai_turns: data[:ai_turns],
+                           without_ai_minutes: data[:without_ai_minutes],
+                           quality_vs_self: data[:quality_vs_self],
+                           notes: data[:notes]
+                         })
     end
 
     def parse_metadata_estimates(metadata)

--- a/lib/toggl_db/cli/task_end_command.rb
+++ b/lib/toggl_db/cli/task_end_command.rb
@@ -425,13 +425,19 @@ module TogglDb
     end
 
     def format_time_range(entry)
-      start_str = entry[:start_time].strftime('%Y-%m-%d %I:%M %p')
-      end_str = if entry[:start_time].to_date == entry[:end_time].to_date
-                  entry[:end_time].strftime('%I:%M %p')
-                else
-                  entry[:end_time].strftime('%Y-%m-%d %I:%M %p')
-                end
-      "#{start_str} - #{end_str}"
+      same_day = entry[:start_time].to_date == entry[:end_time].to_date
+      if same_day
+        # Same day: show date once, then just times
+        date_str = entry[:start_time].strftime('%Y-%m-%d')
+        start_time = entry[:start_time].strftime('%I:%M %p')
+        end_time = entry[:end_time].strftime('%I:%M %p')
+        "#{date_str} #{start_time} - #{end_time}"
+      else
+        # Different days: show full date+time for both
+        start_str = entry[:start_time].strftime('%Y-%m-%d %I:%M %p')
+        end_str = entry[:end_time].strftime('%Y-%m-%d %I:%M %p')
+        "#{start_str} - #{end_str}"
+      end
     end
 
     def format_ai_details(app_breakdown)

--- a/lib/toggl_db/cli/task_end_command.rb
+++ b/lib/toggl_db/cli/task_end_command.rb
@@ -425,7 +425,13 @@ module TogglDb
     end
 
     def format_time_range(entry)
-      "#{entry[:start_time].strftime('%I:%M %p')} - #{entry[:end_time].strftime('%I:%M %p')}"
+      start_str = entry[:start_time].strftime('%Y-%m-%d %I:%M %p')
+      end_str = if entry[:start_time].to_date == entry[:end_time].to_date
+                  entry[:end_time].strftime('%I:%M %p')
+                else
+                  entry[:end_time].strftime('%Y-%m-%d %I:%M %p')
+                end
+      "#{start_str} - #{end_str}"
     end
 
     def format_ai_details(app_breakdown)

--- a/lib/toggl_db/cli/task_start_command.rb
+++ b/lib/toggl_db/cli/task_start_command.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative 'metr_formatter'
+require_relative '../task_store'
+
+module TogglDb
+  class CLI < Thor
+    desc 'task-start', 'Start a new Metr tracked task'
+    long_desc <<~DESC
+      Generates a TASK START template and begins tracking a new task for Metr productivity research.
+
+      Interactive prompts collect all required fields:
+        - Task description
+        - Whether AI will be used
+        - Expected time with AI
+        - Estimated time without AI
+        - Confidence level (1-5)
+        - Why using AI (if applicable)
+        - Whether you would do this without AI
+        - Task type (Code, Debug, Research, etc.)
+
+      Examples:
+        $ toggl_db task-start                      # Interactive mode
+        $ toggl_db task-start --format metr       # Output in strict Metr format
+        $ toggl_db task-start -o ~/tasks.txt      # Write output to file
+    DESC
+    option :id, type: :numeric, desc: 'Specify task ID (default: auto-increment)'
+    option :format, aliases: '-f', type: :string, enum: %w[default metr], default: 'metr',
+                    desc: 'Output format'
+    option :output, aliases: '-o', type: :string, desc: 'Write output to file'
+    def task_start
+      task_data = prompt_task_start_data
+      task = TaskStore.create_task(task_data)
+
+      output = MetrFormatter.format_task_start(task, format: options[:format].to_sym)
+      write_output(output)
+
+      say ''
+      say "Task ##{task['id']} started. Use 'toggl_db task-end' when complete.", :green
+    end
+
+    private
+
+    def prompt_task_start_data
+      say ''
+      say 'Starting new task...', :green
+      say ''
+
+      description = ask('Task description:')
+      use_ai = yes?('Will you use AI? (y/n)')
+      expected_time = ask_numeric('Expected time with AI (minutes):')
+      without_ai_time = ask_numeric('Without AI would take (minutes):')
+      confidence = ask_confidence
+      why_ai = use_ai ? ask('Why use AI for this task?') : nil
+      would_do_without_ai = yes?('Would you do this task without AI? (y/n)')
+      task_type = ask_choice('Task type:', MetrFormatter::TASK_TYPES)
+
+      {
+        description: description,
+        type: task_type,
+        use_ai: use_ai,
+        expected_time_minutes: expected_time,
+        without_ai_time_minutes: without_ai_time,
+        confidence: confidence,
+        why_ai: why_ai,
+        would_do_without_ai: would_do_without_ai
+      }
+    end
+
+    def ask_numeric(prompt, default: nil)
+      default_hint = default ? " [#{default}]" : ''
+      response = ask("#{prompt}#{default_hint}")
+      return default if response.strip.empty? && default
+
+      response.to_i
+    end
+
+    def ask_confidence
+      say 'Confidence level (1-5):'
+      say '  1 = Very uncertain'
+      say '  3 = Moderate confidence'
+      say '  5 = Very confident'
+      response = ask('Select (1-5):')
+      response.to_i.clamp(1, 5)
+    end
+
+    def ask_choice(prompt, choices, default: nil)
+      say prompt
+      choices.each_with_index { |c, i| say "  #{i + 1}. #{c}" }
+      default_hint = default ? " [#{choices.index(default) + 1}]" : ''
+      response = ask("Select (1-#{choices.length})#{default_hint}:")
+
+      return default if response.strip.empty? && default
+
+      idx = response.to_i - 1
+      idx >= 0 && idx < choices.length ? choices[idx] : (default || choices.first)
+    end
+
+    def write_output(content)
+      if options[:output]
+        File.write(options[:output], "#{content}\n")
+        say "Output written to: #{options[:output]}", :green
+      else
+        say ''
+        say content
+      end
+    end
+  end
+end

--- a/lib/toggl_db/task_store.rb
+++ b/lib/toggl_db/task_store.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'fileutils'
+require 'pathname'
+require 'time'
+
+module TogglDb
+  # Persists task tracking data to JSON for Metr productivity research.
+  # Tracks task IDs, task metadata, and associated snapshots.
+  class TaskStore
+    STORE_PATH = File.expand_path('~/.config/toggl_db/tasks.json')
+    VERSION = 1
+
+    class << self
+      def instance
+        @instance ||= new
+      end
+
+      def next_id
+        instance.next_id
+      end
+
+      def create_task(attributes)
+        instance.create_task(attributes)
+      end
+
+      def find_task(id)
+        instance.find_task(id)
+      end
+
+      def current_task
+        instance.current_task
+      end
+
+      def end_task(id, outcome_attributes)
+        instance.end_task(id, outcome_attributes)
+      end
+
+      def add_snapshot(task_id, snapshot_data)
+        instance.add_snapshot(task_id, snapshot_data)
+      end
+
+      def recent_tasks(limit = 10)
+        instance.recent_tasks(limit)
+      end
+
+      def path
+        instance.store_path
+      end
+
+      def reset_instance!
+        @instance = nil
+      end
+    end
+
+    attr_reader :store_path
+
+    def initialize(path = nil)
+      @store_path = Pathname.new(path || STORE_PATH)
+      @data = load_data
+    end
+
+    def next_id
+      @data['last_id'] + 1
+    end
+
+    def create_task(attributes)
+      id = next_id
+      @data['last_id'] = id
+      @data['current_task_id'] = id
+
+      task = {
+        'id' => id,
+        'description' => attributes[:description],
+        'type' => attributes[:type],
+        'use_ai' => attributes[:use_ai],
+        'expected_time_minutes' => attributes[:expected_time_minutes],
+        'without_ai_time_minutes' => attributes[:without_ai_time_minutes],
+        'confidence' => attributes[:confidence],
+        'why_ai' => attributes[:why_ai],
+        'would_do_without_ai' => attributes[:would_do_without_ai],
+        'started_at' => Time.now.iso8601,
+        'ended_at' => nil,
+        'outcome' => nil,
+        'snapshots' => []
+      }
+
+      @data['tasks'] << task
+      save
+      task
+    end
+
+    def find_task(id)
+      @data['tasks'].find { |t| t['id'] == id }
+    end
+
+    def current_task
+      return nil unless @data['current_task_id']
+
+      task = find_task(@data['current_task_id'])
+      # Only return if task is still in progress (not ended)
+      task && task['ended_at'].nil? ? task : nil
+    end
+
+    def end_task(id, outcome_attributes)
+      task = find_task(id)
+      return nil unless task
+
+      task['ended_at'] = Time.now.iso8601
+      task['outcome'] = outcome_attributes[:outcome]
+      task['actual_elapsed_minutes'] = outcome_attributes[:actual_elapsed_minutes]
+      task['active_work_minutes'] = outcome_attributes[:active_work_minutes]
+      task['waiting_ai_minutes'] = outcome_attributes[:waiting_ai_minutes]
+      task['ai_percentage'] = outcome_attributes[:ai_percentage]
+      task['ai_turns'] = outcome_attributes[:ai_turns]
+      task['final_without_ai_minutes'] = outcome_attributes[:without_ai_minutes]
+      task['quality_vs_self'] = outcome_attributes[:quality_vs_self]
+      task['notes'] = outcome_attributes[:notes]
+
+      # Clear current task if it matches
+      @data['current_task_id'] = nil if @data['current_task_id'] == id
+
+      save
+      task
+    end
+
+    def add_snapshot(task_id, snapshot_data)
+      task = find_task(task_id)
+      return nil unless task
+
+      snapshot = {
+        'time' => snapshot_data[:time]&.iso8601 || Time.now.iso8601,
+        'ai_involved' => snapshot_data[:ai_involved],
+        'focus' => snapshot_data[:focus],
+        'same_task' => snapshot_data[:same_task],
+        'ai_vanished_impact' => snapshot_data[:ai_vanished_impact],
+        'what' => snapshot_data[:what],
+        'type' => snapshot_data[:type]
+      }
+
+      task['snapshots'] << snapshot
+      save
+      snapshot
+    end
+
+    def recent_tasks(limit = 10)
+      @data['tasks'].last(limit).reverse
+    end
+
+    def all_tasks
+      @data['tasks']
+    end
+
+    def save
+      FileUtils.mkdir_p(@store_path.dirname)
+      File.write(@store_path, JSON.pretty_generate(@data))
+    end
+
+    def exists?
+      @store_path.exist?
+    end
+
+    private
+
+    def load_data
+      if @store_path.exist?
+        loaded = JSON.parse(File.read(@store_path))
+        migrate_if_needed(loaded)
+      else
+        default_data
+      end
+    rescue JSON::ParserError
+      default_data
+    end
+
+    def default_data
+      {
+        'version' => VERSION,
+        'last_id' => 0,
+        'current_task_id' => nil,
+        'tasks' => []
+      }
+    end
+
+    def migrate_if_needed(data)
+      # Future migrations can be handled here based on version
+      data['version'] ||= VERSION
+      data['current_task_id'] ||= nil
+      data['tasks'] ||= []
+      data['last_id'] ||= 0
+      data
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements comprehensive Metr productivity tracking support for the toggl_db CLI:

- **task-start**: Begin tracking a new task with auto-increment ID, collecting all required Metr fields (description, AI usage, expected time, without-AI estimate, confidence, task type)
- **snapshot**: Record point-in-time work status snapshots with AI involvement, focus level, and impact assessment
- **status**: Show current in-progress task and recent task history
- **task-end**: Now supports `--format metr` flag for strict Metr output format matching the official template

### New Infrastructure

- **TaskStore**: JSON-based persistence for task tracking stored at `~/.config/toggl_db/tasks.json`
- **MetrFormatter**: Formatters supporting both default (human-friendly) and strict Metr formats
- **--output FILE**: Option for writing reports to files instead of stdout

### Metr Format Templates

**TASK START:**
```
=== TASK START ===
Task ID: [number]
Time: [current time]
Description: [user input]
...
```

**TASK END:**
```
=== TASK END ===
Task ID: [number]
Time: [end time]

1. USED AI? [Yes / No]
2. TOTAL ELAPSED: ___ min
3. TIME BREAKDOWN:
   Active work: ___ min
   Waiting/reviewing AI: ___ min
...
```

**SNAPSHOT:**
```
=== SNAPSHOT ===
Time: [now]

1. AI INVOLVED? [No / Yes-waiting / Yes-actively using / Yes-using output]
2. FOCUS: [Fully on one thing / Switching / Distracted]
...
```

## Test plan

- [ ] Run `toggl_db task-start` and verify interactive prompts work
- [ ] Run `toggl_db status` to see created task
- [ ] Run `toggl_db snapshot` to record a snapshot
- [ ] Run `toggl_db task-end --format metr` to generate Metr-formatted output
- [ ] Verify `--output FILE` writes to file correctly
- [ ] Run `bundle exec rubocop` - should pass with no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)